### PR TITLE
feat: Update Firebase App Distribution GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,9 @@ jobs:
           SIGNING_KEY_FILE: release.keystore
         run: ./gradlew bundleRelease
 
-      - name: Upload artifact to Firebase App Distribution
-        uses: google-github-actions/distribute-app-distribution@v1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          groups: testers
-          file: app/build/outputs/bundle/release/app-release.aab
+      - name: Distribute to Firebase App Distribution
+        run: |
+          npx --yes firebase-tools app:distribute app/build/outputs/bundle/release/app-release.aab \
+            --app "${{ secrets.FIREBASE_APP_ID }}" \
+            --token "${{ secrets.FIREBASE_TOKEN }}" \
+            --groups "testers"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,9 +1,6 @@
 name: Review Distribution
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -30,10 +27,9 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
 
-      - name: Upload to Firebase App Tester
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }} # Add your Firebase App ID as a secret
-          token: ${{ secrets.FIREBASE_TOKEN }}
-          groups: testers # Your tester group
-          file: app/build/outputs/apk/debug/app-debug.apk
+      - name: Distribute debug APK to Firebase App Distribution
+        run: |
+          npx --yes firebase-tools app:distribute app/build/outputs/apk/debug/app-debug.apk \
+            --app "${{ secrets.FIREBASE_APP_ID }}" \
+            --token "${{ secrets.FIREBASE_TOKEN }}" \
+            --groups "testers"


### PR DESCRIPTION
This commit updates the `release.yml` workflow to use the official `firebase/firebase-app-distribution-action@v1` GitHub Action, replacing the deprecated `wzieba/firebase-app-distribution-action@v1`.